### PR TITLE
Use master branch of moj-module-postgres module

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -47,11 +47,11 @@ resource "vault_generic_secret" "servicebus-listen-conn-string" {
 }
 
 module "db" {
-  source              = "git@github.com:contino/moj-module-postgres.git?ref=feature/specify-db-name"
+  source              = "git@github.com:contino/moj-module-postgres.git?ref=master"
   product             = "${var.product}"
   location            = "${var.location_db}"
   env                 = "${var.env}"
-  postgresql_database = "letter_tracking"
+  postgresql_database = "postgres"
   postgresql_user     = "letter_tracking"
 }
 


### PR DESCRIPTION
### Change description ###

Use master branch of moj-module-postgres module

Tested here:
https://sandbox-build.platform.hmcts.net/job/HMCTS/job/send-letter-producer-service/job/cnp/23/

IMPORTANT: it will stop using the old (`letter_tracking`) database and will start using `postgres` database instead.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
